### PR TITLE
Add cluster health check

### DIFF
--- a/talos.tf
+++ b/talos.tf
@@ -182,3 +182,19 @@ resource "talos_machine_configuration_apply" "worker" {
     })
   ]
 }
+resource "talos_cluster_health" "this" {
+  depends_on = [
+    talos_machine_configuration_apply.controlplane,
+    talos_machine_configuration_apply.worker,
+    talos_machine_bootstrap.this,
+  ]
+
+  client_configuration = talos_machine_secrets.this.client_configuration
+  endpoints = [
+    for k, v in proxmox_virtual_environment_vm.nodes : v.ipv4_addresses[index(v.network_interface_names, var.network_interface)][0]
+    if startswith(k, "controlplane-")
+  ]
+  nodes = [
+    for k, v in proxmox_virtual_environment_vm.nodes : v.ipv4_addresses[index(v.network_interface_names, var.network_interface)][0]
+  ]
+}


### PR DESCRIPTION
## Summary
- add `talos_cluster_health` resource that waits for controlplane and worker nodes

## Testing
- `terraform` not installed so no tests run

------
https://chatgpt.com/codex/tasks/task_b_686cba016d7c8330a4c936afb6ae9807